### PR TITLE
Support user-specified runtime via args.runtime parameter

### DIFF
--- a/example/dist/index.htm
+++ b/example/dist/index.htm
@@ -1,0 +1,12 @@
+hello word <!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Document</title>
+</head>
+<body>
+  Hello world
+</body>
+</html>

--- a/example/dist/index.html
+++ b/example/dist/index.html
@@ -1,0 +1,12 @@
+hello word <!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Document</title>
+</head>
+<body>
+  Hello world
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
     "rimraf": "^5.0.5"
   },
   "devDependencies": {
+    "@types/fs-extra": "^11.0.4",
+    "@types/jest": "^30.0.0",
+    "@types/node": "^25.2.2",
     "jest": "^27.5.1"
   },
   "jest": {

--- a/readme.md
+++ b/readme.md
@@ -78,6 +78,7 @@ services:
 | 参数名称 | 默认值 | 参数含义 | 必填 |
 | --- | --- | --- |--- |
 | index  | index.html |  自定义默认首页    | false |
+| runtime  | custom |  自定义函数运行时    | false |
 
 
 我们知道访问静态网站需要一个`html`的页面作为首页，比如您访问`http://www.serverless-devs.com/`首页的时候，其实实际访问的资源是`http://www.serverless-devs.com/index.html`。
@@ -90,6 +91,19 @@ actions: # 自定义执行逻辑
       args:
         index: demo.html
 ```
+
+**自定义运行时**
+
+`website-fc`插件默认会将函数的运行时设置为`custom`。如果您需要使用其他运行时（如 `custom.debian11`、`nodejs14`、`nodejs16` 等），可以通过 `runtime` 参数指定：
+```
+actions: # 自定义执行逻辑
+  pre-deploy: # 在deploy之前运行
+    - plugin: website-fc
+      args:
+        runtime: custom.debian11
+```
+
+当您指定了 `runtime` 参数后，插件将优先使用您指定的运行时，而不是默认的 `custom` 运行时。
 
 可以参考[案例](https://github.com/devsapp/start-realwrold/tree/master/src)
 

--- a/readme.md
+++ b/readme.md
@@ -92,7 +92,7 @@ actions: # 自定义执行逻辑
 
 **自定义运行时**
 
-`website-fc`插件默认会将函数的运行时设置为`custom`。如果您需要使用其他运行时（如 `custom.debian11`、`nodejs14`、`nodejs16` 等），可以通过 `runtime` 参数指定：
+`website-fc`插件默认会将函数的运行时设置为`custom`。如果您需要使用其他运行时（如 `custom.debian11` 等），可以通过 `runtime` 参数指定：
 ```
 actions: # 自定义执行逻辑
   pre-deploy: # 在deploy之前运行

--- a/src/index.js
+++ b/src/index.js
@@ -35,10 +35,11 @@ module.exports = async function index(inputs, args) {
     path.join(__dirname, "./code/index.js"),
     lodash.replace(indexData, "$index", index)
   );
+  const runtime = lodash.get(args, "runtime", "custom");
   return lodash.merge(inputs, {
     props: {
       function: {
-        runtime: "custom",
+        runtime,
         codeUri: path.join(__dirname, "./code"), // 支持ZIP能力
         customRuntimeConfig: {
           command: ["node"],

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ module.exports = async function index(inputs, args, logger) {
   logger?.debug(`inputs params: ${JSON.stringify(inputs)}`);
   logger?.debug(`args params: ${JSON.stringify(args)}`);
   const codeUri = lodash.get(inputs, "props.code");
-  if (lodash.isEmpty(codeUri)) return;
+  if (lodash.isEmpty(codeUri)) throw new Error("props.code not found.");
   const bashPath = lodash.get(inputs, "cwd");
   const newCodeUri = path.isAbsolute(codeUri)
     ? codeUri

--- a/src/index.js
+++ b/src/index.js
@@ -12,8 +12,8 @@ const rimraf = require("rimraf");
  */
 
 module.exports = async function index(inputs, args, logger) {
-  logger.debug(`inputs params: ${JSON.stringify(inputs)}`);
-  logger.debug(`args params: ${JSON.stringify(args)}`);
+  logger?.debug(`inputs params: ${JSON.stringify(inputs)}`);
+  logger?.debug(`args params: ${JSON.stringify(args)}`);
   const codeUri = lodash.get(inputs, "props.code");
   if (lodash.isEmpty(codeUri)) return;
   const bashPath = lodash.get(inputs, "cwd");

--- a/src/index.js
+++ b/src/index.js
@@ -17,9 +17,16 @@ module.exports = async function index(inputs, args, logger) {
   const codeUri = lodash.get(inputs, "props.code");
   if (lodash.isEmpty(codeUri)) throw new Error("props.code not found.");
   const bashPath = lodash.get(inputs, "cwd");
-  const newCodeUri = path.isAbsolute(codeUri)
-    ? codeUri
-    : path.join(bashPath, codeUri);
+  let newCodeUri = path.isAbsolute(codeUri)
+      ? codeUri
+      : path.join(bashPath, codeUri);
+
+  // Resolve symbolic link to actual directory
+  const stats = fse.lstatSync(newCodeUri);
+  if (stats.isSymbolicLink()) {
+    newCodeUri = fse.realpathSync(newCodeUri);
+    logger.debug(`Resolved symbolic link to actual path: ${newCodeUri}`);
+  }
   const publicPath = path.join(__dirname, "./code/public");
 
   rimraf.sync(publicPath);

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -2,53 +2,46 @@ let subject = require("../src/index");
 let fs = require("fs");
 const path = require("path");
 
+let exampleDir = path.join(__dirname, "../example");
 let exampleDist = path.join(__dirname, "../example/dist");
 let exampleTmpl = path.join(__dirname, "../example/s.yaml");
 let outputDir = path.join(__dirname, "../src/code/public");
 
-test('props.function.codeUri not present', async function () {
-    let result = await subject({}, {});
-    expect(result).toBeUndefined();
+test('props.codeUri not present', async function () {
+    try {
+        await subject({}, {});
+        fail();
+    } catch (e) {
+        expect(e.message).toBe("props.code not found.");
+    }
+
 });
 
-test('path.configPath not present', async function () {
-    let catchTriggered = false;
-    try {
-        await subject({
-            props: {
-                function: {
-                    codeUri: exampleDist
-                }
-            }
-        }, {});
-    } catch (e) {
-        expect(e.code).toBe("ERR_INVALID_ARG_TYPE");
-        expect(e.message.toString().includes("The \"path\" argument must be of type string.")).toBeTruthy();
-        catchTriggered = true;
-    }
-    expect(catchTriggered).toBeTruthy();
+test('path.cwd not present', async function () {
+    let result = await subject({
+        props: {
+            code: exampleDist
+        }
+    }, {});
+    expect(result.props.code).toBe(path.join(__dirname, "../src/code"));
 });
 
 test('default index.html', async function () {
     let result = await subject({
-        path: {
-            configPath: exampleTmpl
-        },
+        cwd: exampleDir,
         props: {
-            function: {
-                codeUri: exampleDist
-            }
+            code: exampleDist
         }
     }, {});
 
     // content are copied from exampleDist to outputDir
     expect(fs.readdirSync(outputDir)).toStrictEqual(fs.readdirSync(exampleDist));
 
-    expect(result.props.function.runtime).toBe("custom");
-    expect(result.props.function.codeUri).toBe(path.join(__dirname, "../src/code"));
-    expect(result.props.function.caPort).toBe(9000);
-    expect(result.props.function.customRuntimeConfig.command).toStrictEqual(["node"]);
-    expect(result.props.function.customRuntimeConfig.args).toStrictEqual(["/code/index.js"]);
+    expect(result.props.runtime).toBe("custom");
+    expect(result.props.code).toBe(path.join(__dirname, "../src/code"));
+    expect(result.props.caPort).toBe(9000);
+    expect(result.props.customRuntimeConfig.command).toStrictEqual(["node"]);
+    expect(result.props.customRuntimeConfig.args).toStrictEqual(["/code/index.js"]);
 
     let generatedIndexContent = fs.readFileSync(path.join(__dirname, "../src/code/index.js")).toString();
     expect(generatedIndexContent.includes("index.html")).toBeTruthy();
@@ -57,30 +50,21 @@ test('default index.html', async function () {
 test('relative codeUri', async function () {
     let originCodeUri = "./dist";
     let inputs = {
-        path: {
-            configPath: exampleTmpl
-        },
+        cwd: exampleDir,
         props: {
-            function: {
-                codeUri: originCodeUri
-            }
+            code: originCodeUri
         }
     };
-    await subject(inputs, {});
+    let result = await subject(inputs, {});
 
-    let joinedPath = path.join(path.dirname(inputs.path.configPath), originCodeUri);
-    expect(fs.readdirSync(outputDir)).toStrictEqual(fs.readdirSync(joinedPath));
+    expect(result.props.code).toBe(path.join(__dirname, "../src/code"));
 });
 
 test('custom index.htm', async function () {
     await subject({
-        path: {
-            configPath: exampleTmpl
-        },
+        cwd: exampleDir,
         props: {
-            function: {
-                codeUri: exampleDist
-            }
+            code: exampleDist
         }
     }, {
         index: "index.htm"
@@ -92,21 +76,17 @@ test('custom index.htm', async function () {
 
 test('should prioritize user-provided runtime over default', async function () {
     let result = await subject({
-        path: {
-            configPath: exampleTmpl
-        },
+        cwd: exampleDir,
         props: {
-            function: {
-                codeUri: exampleDist
-            }
+            code: exampleDist
         }
     }, {
         runtime: "custom.debian11"
     });
 
-    expect(result.props.function.runtime).toBe("custom.debian11");
-    expect(result.props.function.codeUri).toBe(path.join(__dirname, "../src/code"));
-    expect(result.props.function.caPort).toBe(9000);
+    expect(result.props.runtime).toBe("custom.debian11");
+    expect(result.props.code).toBe(path.join(__dirname, "../src/code"));
+    expect(result.props.caPort).toBe(9000);
 });
 
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,5 +1,6 @@
 let subject = require("../src/index");
 let fs = require("fs");
+const fse = require("fs-extra");
 const path = require("path");
 
 let exampleDir = path.join(__dirname, "../example");
@@ -72,6 +73,40 @@ test('custom index.htm', async function () {
 
     let generatedIndexContent = fs.readFileSync(path.join(__dirname, "../src/code/index.js")).toString();
     expect(generatedIndexContent.includes("index.htm")).toBeTruthy();
+});
+
+test('props.code is a symlink', async function () {
+    const symlinkPath = path.join(__dirname, "../example/dist-link");
+    // Clean up symlink if it exists from a previous test run
+    if (fse.existsSync(symlinkPath)) {
+        fse.removeSync(symlinkPath);
+    }
+    // Create a junction (works without admin privileges on Windows) or symlink
+    fse.ensureSymlinkSync(exampleDist, symlinkPath, 'junction');
+
+    const mockLogger = { debug: jest.fn() };
+
+    try {
+        let result = await subject({
+            cwd: exampleDir,
+            props: {
+                code: symlinkPath
+            }
+        }, {}, mockLogger);
+
+        // content are copied from the resolved actual directory to outputDir
+        expect(fs.readdirSync(outputDir)).toStrictEqual(fs.readdirSync(exampleDist));
+
+        expect(result.props.code).toBe(path.join(__dirname, "../src/code"));
+
+        // Verify that the symlink was resolved and logger was called
+        expect(mockLogger.debug).toHaveBeenCalledWith(
+            expect.stringContaining("Resolved symbolic link to actual path:")
+        );
+    } finally {
+        // Clean up symlink after test
+        fse.removeSync(symlinkPath);
+    }
 });
 
 test('should prioritize user-provided runtime over default', async function () {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -90,4 +90,23 @@ test('custom index.htm', async function () {
     expect(generatedIndexContent.includes("index.htm")).toBeTruthy();
 });
 
+test('should prioritize user-provided runtime over default', async function () {
+    let result = await subject({
+        path: {
+            configPath: exampleTmpl
+        },
+        props: {
+            function: {
+                codeUri: exampleDist
+            }
+        }
+    }, {
+        runtime: "custom.debian11"
+    });
+
+    expect(result.props.function.runtime).toBe("custom.debian11");
+    expect(result.props.function.codeUri).toBe(path.join(__dirname, "../src/code"));
+    expect(result.props.function.caPort).toBe(9000);
+});
+
 


### PR DESCRIPTION
This pull request introduces support for customizing the function runtime, improves error handling, and updates tests and documentation to reflect these changes. 
Now, users can specify a custom runtime via the `runtime` parameter, and the code will throw an explicit error if the required `code` property is missing. The tests and documentation have been updated accordingly.

**Custom Runtime Support**
- Added support for a `runtime` parameter, allowing users to specify a custom function runtime (e.g., `custom.debian11`) instead of the default `custom` runtime in `src/index.js`. The plugin now prioritizes the user-provided runtime if specified.
- Updated documentation (`readme.md`) to explain the new `runtime` parameter and provide usage examples. [[1]](diffhunk://#diff-5a831ea67cf5cf8703b0de46901ab25bd191f56b320053be9332d9a3b0d01d15R79) [[2]](diffhunk://#diff-5a831ea67cf5cf8703b0de46901ab25bd191f56b320053be9332d9a3b0d01d15R93-R105)

**Error Handling Improvements**
- Changed behavior to throw an explicit error if `props.code` is missing, improving clarity for users.

**Testing Enhancements**
- Updated and expanded tests in `test/index.spec.js` to cover the new error handling and custom runtime logic. This includes a new test to verify that the user-provided runtime is prioritized. [[1]](diffhunk://#diff-64e1a074e043e83910a596c1b325fa13957239515534f504e1b37d62a2efbbbdR5-R44) [[2]](diffhunk://#diff-64e1a074e043e83910a596c1b325fa13957239515534f504e1b37d62a2efbbbdR77-R91)

**Development Dependencies**
- Added type definitions for `fs-extra`, `jest`, and `node` to `package.json` to improve type safety and developer experience.